### PR TITLE
Upgrade to JVM 25

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: 17
+          java-version: 25
           cache: "gradle"
 
       - name: Fix Error Prone issues

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: 17
+          java-version: 25
           cache: "gradle"
       - name: Assemble
         run: ./gradlew assemble
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: 17
+          java-version: 25
           cache: "gradle"
       - name: Run tests
         run: ./gradlew test
@@ -74,7 +74,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: 17
+          java-version: 25
           cache: "gradle"
       - name: Check formatting
         run: ./gradlew spotlessCheck

--- a/.idx/dev.nix
+++ b/.idx/dev.nix
@@ -5,7 +5,7 @@
   channel = "stable-23.11"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
   packages = [
-    pkgs.jdk17
+    pkgs.jdk25
   ];
   # Sets environment variables in the workspace
   env = {};

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,8 @@ subprojects {
 
 	java {
 		toolchain {
-			languageVersion = JavaLanguageVersion.of(17)
+			languageVersion = JavaLanguageVersion.of(25)
+			vendor = JvmVendorSpec.ADOPTIUM
 		}
 	}
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-java = "temurin-17.0.17+10"
+java = "temurin-25.0.1+8.0.LTS"

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,6 +26,10 @@ pluginManagement {
 	}
 }
 
+plugins {
+	id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
+
 Properties props = System.getProperties();
 props.setProperty("org.gradle.internal.native.headers.unresolved.dependencies.ignore", "true");
 


### PR DESCRIPTION
Upgrades local dev environments to use JVM 25, while keeping generated bytecode compatible with Java v17

Should just work (including automatically downloading and bootstrapping the JDK if needed)

This unblocks #168